### PR TITLE
Add a “not me” link to the CV upload page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -145,6 +145,11 @@ footer ul.pull-right li:last-child {
   margin-bottom: 2em;
 }
 
+#upload_cv .not_me {
+    font-size: 15px;
+    margin-left: 0.5em;
+}
+
 /* /show_cv */
 
 /* See http://stackoverflow.com/a/12121929/284340 */

--- a/templates/upload_cv_confirmed.html
+++ b/templates/upload_cv_confirmed.html
@@ -3,7 +3,7 @@
 {% block body %}
     <div id="upload_cv">
 
-        <h1>Hello, {{ candidate.name }}</h1>
+        <h1>Hello, {{ candidate.name }} <a class="not_me" href="/clear_postcode">That’s not me</a></h1>
 
         <p class="lead">Choose your CV to share.</p>
 


### PR DESCRIPTION
It’s possible candidates will share their upload page – particularly if
we mail merge these unique URLs.
