### PR TITLE
Ensure email is not None before adding to session

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,8 +160,9 @@ def upload_cv_confirmed(person_id, signature):
         flask.flash("Sorry! That web link isn't right. Can you check you copied it properly from your email?", 'warning')
         return error()
 
-    # this is their default email now
-    flask.session['email'] = candidate['email']
+    if candidate['email'] is not None:
+        # this is their default email now
+        flask.session['email'] = candidate['email']
 
     upload_link = flask.url_for('upload_cv_upload', person_id=person_id, signature=signature)
 


### PR DESCRIPTION
It’s very unlikely this could happen! It would require either:
- a candidate to have received their unique link by means other than email (e.g. a direct facebook message? A LinkedIn InMail™?)
- an email address to have been removed from YourNextMP since the candidate received the email with their unique link

If it happens, though, it causes the constituency page (and possibly others) to error.
