### PR TITLE
Don’t wait 10 seconds for “No preview” text

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -28,7 +28,7 @@ def gen_thumbs():
             lookups.add_thumb(main.app.config, x["person_id"], filename + ".jpg", extension="jpg")
             os.remove(filename)
             os.remove(filename + ".jpg")
-        except:
+        except subprocess.CalledProcessError:
             print("Failed to make thumb for person ", str(x["person_id"]))
             print(traceback.format_exc())
             msg = flask_mail.Message(body=traceback.format_exc(),

--- a/screenshot.js
+++ b/screenshot.js
@@ -56,12 +56,12 @@ page.open(url, function (status) {
                     return $(['role=\"document\"']).length > 0;
                 });
             }, function() {
+                if (page.content.indexOf("No preview available") > -1) {
+                    phantom.exit(3);
+                }
+
                 // wait another 10 seconds (until page num and toolbar disappear)
                 setTimeout(function () {
-                    if (page.content.indexOf("No preview available") > -1) {
-                        phantom.exit(3);
-                    }
-
                     page.clipRect = {
                       top: clip,
                       left: clip,


### PR DESCRIPTION
I _think_ the current solution to #56 will return a completely black jpeg preview on fail (that’s what happens for me locally, anyway).

The reason is, phantom.exit(3) doesn’t appear to be returning the right error code when it’s used inside the setTimeout like this… But I don’t think it needs to be called from there anyway.
